### PR TITLE
v0.2.20230609: Allow building with optparse-applicative version 0.18

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230312
+# version: 0.16.4
 #
-# REGENDATA ("0.15.20230312",["github","cabal-clean.cabal"])
+# REGENDATA ("0.16.4",["github","cabal-clean.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,19 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -92,7 +92,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -101,7 +101,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -179,8 +179,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.2.20230609
+------------
+
+Build with `optparse-applicative-0.18`:
+PR [#4](https://github.com/andreasabel/cabal-clean/pull/4) by Sanchayan Maity.
+
 0.2.20220819
 ------------
 

--- a/cabal-clean.cabal
+++ b/cabal-clean.cabal
@@ -1,7 +1,7 @@
 cabal-version:       >=1.10
 
 name:                cabal-clean
-version:             0.2.20220819
+version:             0.2.20230609
 synopsis:            Remove outdated cabal build artefacts from `dist-newstyle`.
 
 description:         Simple command line tool to remove cabal build artefacts
@@ -62,8 +62,8 @@ executable cabal-clean
     , filepath
     -- , filepath == 1.4.*
     , mtl
-    , optparse-applicative
-    -- , optparse-applicative >= 0.13 && < 0.16
+    -- missing Semigroup instances with optparse-applicative-0.12
+    , optparse-applicative >= 0.13
     -- pretty-terminal-0.1.0.0 has base >= 4.9
     , pretty-terminal
     , process
@@ -75,30 +75,9 @@ executable cabal-clean
   default-language:    Haskell2010
 
   default-extensions:
-    -- BangPatterns
-    -- ConstraintKinds
-    -- DefaultSignatures
-    -- DeriveDataTypeable
-    -- DeriveFoldable
-    -- DeriveFunctor
-    -- DeriveTraversable
-    -- ExistentialQuantification
-    -- FlexibleContexts
-    -- FlexibleInstances
-    -- FunctionalDependencies
-    -- InstanceSigs
     LambdaCase
-    -- MultiParamTypeClasses
-    -- MultiWayIf
-    -- NamedFieldPuns
-    -- OverloadedStrings
-    -- PatternSynonyms
-    -- RankNTypes
     RecordWildCards
-    -- ScopedTypeVariables
-    -- StandaloneDeriving
     TupleSections
-    -- TypeSynonymInstances
 
   ghc-options:
     -Wall

--- a/cabal-clean.cabal
+++ b/cabal-clean.cabal
@@ -24,9 +24,9 @@ extra-source-files:  CHANGELOG.md
                      README.md
 
 tested-with:
-  GHC == 9.6.1
-  GHC == 9.4.4
-  GHC == 9.2.7
+  GHC == 9.6.2
+  GHC == 9.4.5
+  GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -15,7 +15,7 @@ import Options.Applicative
   , info, infoOption, long, metavar, short, strArgument, switch, value
   )
 import Options.Applicative.Help.Pretty
-  ( vcat, text )
+  ( vcat, pretty )
 
 import System.Console.Pretty
   ( supportsPretty )
@@ -163,7 +163,7 @@ options = do
       <> help (concat ["The root of the build tree. Default: ", show defaultRoot, "."])
 
   -- Note: @header@ does not respect line breaks, so we need @headerDoc@.
-  header = Just $ vcat $ map text
+  header = Just $ vcat $ map pretty
     [ unwords [ versionText, homepage ]
     , ""
     , concat
@@ -179,7 +179,7 @@ options = do
     , ""
     , "Limitation: Only GHC is recognized as Haskell compiler, and only in the form 'ghc-VERSION' (not just 'ghc')."
     ]
-  footer = Just $ vcat $ map (text . unwords)
+  footer = Just $ vcat $ map (pretty . unwords)
     [ [ unwords ["Without option --delete,", self, "does not actually clean out anything,"]
       , "just shows prefixed with '---' and in red what would be removed and prefixed with '+++' and in green what is kept."
       ]


### PR DESCRIPTION
The function `text :: String -> Doc` has been removed from version 0.18.0 and later.